### PR TITLE
Ironblocks Firewall

### DIFF
--- a/contracts/AdvancedProviders/BundleProvider/BundleProvider.sol
+++ b/contracts/AdvancedProviders/BundleProvider/BundleProvider.sol
@@ -7,8 +7,9 @@ import "../../interfaces/ISimpleProvider.sol";
 import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "../../ERC165/Bundable.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
-contract BundleProvider is BundleModifiers, ERC721Holder {
+contract BundleProvider is BundleModifiers, ERC721Holder, FirewallConsumer {
     using CalcUtils for uint256;
 
     constructor(ILockDealNFT _lockDealNFT) {
@@ -28,7 +29,7 @@ contract BundleProvider is BundleModifiers, ERC721Holder {
         address[] calldata addresses,
         uint256[][] calldata providerParams,
         bytes calldata signature
-    ) external validAddressesLength(addresses.length, 4) returns (uint256 poolId) {
+    ) external firewallProtected validAddressesLength(addresses.length, 4) returns (uint256 poolId) {
         uint256 providerCount = addresses.length - 2;
         require(providerCount == providerParams.length, "providers and params length mismatch");
         uint256 totalAmount = _calcTotalAmount(providerParams);
@@ -51,20 +52,26 @@ contract BundleProvider is BundleModifiers, ERC721Holder {
         uint256[] calldata params
     )
         external
+        firewallProtected
         override
         validBundleParams(poolId, params[0])
         onlyProvider
-        validParamsLength(params.length, currentParamsTargetLenght())
+        validParamsLength(params.length, currentParamsTargetLength())
     {
         _registerPool(poolId, params);
     }
 
     ///@param params[0] = lastSubPoolId
-    function _registerPool(uint256 poolId, uint256[] memory params) internal validLastPoolId(poolId, params[0]) {
+    function _registerPool(uint256 poolId, uint256[] memory params)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25)))
+        validLastPoolId(poolId, params[0])
+    {
         bundlePoolIdToLastSubPoolId[poolId] = params[0];
         emit UpdateParams(poolId, params);
     }
 
+    // Since this just performs checks and calls itself essentially, no firewall protected needed
     function _createNewSubPool(
         address provider,
         uint256[] memory params
@@ -72,11 +79,14 @@ contract BundleProvider is BundleModifiers, ERC721Holder {
         _createNewSubPool(IProvider(provider), params);
     }
 
-    function _createNewSubPool(IProvider provider, uint256[] memory params) internal {
+    function _createNewSubPool(IProvider provider, uint256[] memory params)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0xc763c9c5)))
+    {
         provider.registerPool(lockDealNFT.mintForProvider(address(this), provider), params);
     }
 
-    function withdraw(uint256 poolId) public override onlyNFT returns (uint256 withdrawnAmount, bool isFinal) {
+    function withdraw(uint256 poolId) external override firewallProtected onlyNFT returns (uint256 withdrawnAmount, bool isFinal) {
         // withdraw the sub pools
         uint256 lastSubPoolId = bundlePoolIdToLastSubPoolId[poolId];
         isFinal = true;
@@ -89,7 +99,7 @@ contract BundleProvider is BundleModifiers, ERC721Holder {
         }
     }
 
-    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) public override onlyProvider {
+    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) external override firewallProtected onlyProvider {
         uint256 oldLastSubPoolId = bundlePoolIdToLastSubPoolId[oldPoolId];
         for (uint256 i = oldPoolId + 1; i <= oldLastSubPoolId; ++i) {
             // split the sub poold
@@ -100,7 +110,7 @@ contract BundleProvider is BundleModifiers, ERC721Holder {
     }
 
     function getParams(uint256 poolId) public view override returns (uint256[] memory params) {
-        params = new uint256[](currentParamsTargetLenght() + 1);
+        params = new uint256[](currentParamsTargetLength() + 1);
         params[0] = getTotalRemainingAmount(poolId);
         params[1] = bundlePoolIdToLastSubPoolId[poolId];
     }

--- a/contracts/AdvancedProviders/BundleProvider/BundleProvider.sol
+++ b/contracts/AdvancedProviders/BundleProvider/BundleProvider.sol
@@ -64,7 +64,7 @@ contract BundleProvider is BundleModifiers, ERC721Holder, FirewallConsumer {
     ///@param params[0] = lastSubPoolId
     function _registerPool(uint256 poolId, uint256[] memory params)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25)))
+        firewallProtectedSig(0xdf3aac25)
         validLastPoolId(poolId, params[0])
     {
         bundlePoolIdToLastSubPoolId[poolId] = params[0];
@@ -81,7 +81,7 @@ contract BundleProvider is BundleModifiers, ERC721Holder, FirewallConsumer {
 
     function _createNewSubPool(IProvider provider, uint256[] memory params)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0xc763c9c5)))
+        firewallProtectedSig(0xc763c9c5)
     {
         provider.registerPool(lockDealNFT.mintForProvider(address(this), provider), params);
     }

--- a/contracts/AdvancedProviders/CollateralProvider/CollateralProvider.sol
+++ b/contracts/AdvancedProviders/CollateralProvider/CollateralProvider.sol
@@ -38,7 +38,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState, Fir
     /// @param params[params.length - 1] = FinishTime
     function _registerPool(uint256 poolId, uint256[] calldata params)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25)))
+        firewallProtectedSig(0xdf3aac25)
     {
         uint256 tokenAmount = params[0];
         uint256 mainCoinAmount = params[params.length - 2];
@@ -60,7 +60,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState, Fir
 
     function _setPoolProperties(uint256 poolId, uint256 rate, uint256 finishTime, uint256 mainCoinAmount)
         private
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x91666b02)))
+        firewallProtectedSig(0x91666b02)
     {
         poolIdToRateToWei[poolId] = rate;
         poolIdToTime[poolId] = finishTime;
@@ -69,16 +69,13 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState, Fir
         provider.registerPool(poolId + 3, mainCoinParams); // Just need the 0 index, token left amount
     }
 
-    function _mintNFTs() private firewallProtectedCustom(abi.encodePacked(bytes4(0x1cd0f8c5))) returns (uint256 poolId) {
+    function _mintNFTs() private firewallProtectedSig(0x1cd0f8c5) returns (uint256 poolId) {
         lockDealNFT.mintForProvider(address(this), provider); // Main Coin Collector
         lockDealNFT.mintForProvider(address(this), provider); // Token Collector
         poolId = lockDealNFT.mintForProvider(address(this), provider);
     }
 
-    function _cloneVaultIds(uint256 mainCoinPoolId)
-        private
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x720a8731)))
-    {
+    function _cloneVaultIds(uint256 mainCoinPoolId) private firewallProtectedSig(0x720a8731) {
         lockDealNFT.cloneVaultId(mainCoinPoolId + 1, mainCoinPoolId);
         lockDealNFT.cloneVaultId(mainCoinPoolId + 3, mainCoinPoolId);
     }
@@ -102,7 +99,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState, Fir
         _splitter(coinHolderAmount, mainCoinHolderId, ratio);
     }
 
-    function _splitter(uint256 amount, uint256 poolId, uint256 ratio) internal firewallProtectedCustom(abi.encodePacked(bytes4(0x203fb415))) {
+    function _splitter(uint256 amount, uint256 poolId, uint256 ratio) internal firewallProtectedSig(0x203fb415) {
         if (amount > 0) {
             lockDealNFT.safeTransferFrom(address(this), address(lockDealNFT), poolId, abi.encode(ratio));
         } else {
@@ -134,7 +131,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState, Fir
         _deposit(mainCoinCollectorId, mainCoinAmount);
     }
 
-    function _deposit(uint256 poolId, uint256 amount) internal firewallProtectedCustom(abi.encodePacked(bytes4(0xf3207723))) {
+    function _deposit(uint256 poolId, uint256 amount) internal firewallProtectedSig(0xf3207723) {
         uint256[] memory params = provider.getParams(poolId);
         params[0] += amount;
         provider.registerPool(poolId, params);

--- a/contracts/AdvancedProviders/CollateralProvider/CollateralProvider.sol
+++ b/contracts/AdvancedProviders/CollateralProvider/CollateralProvider.sol
@@ -5,8 +5,9 @@ import "../../interfaces/IFundsManager.sol";
 import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import "./CollateralState.sol";
 import "../../util/CalcUtils.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
-contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
+contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState, FirewallConsumer {
     using CalcUtils for uint256;
 
     ///@dev withdraw tokens
@@ -21,11 +22,12 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         uint256 poolId,
         uint256[] calldata params
     )
-        public
+        external
         override
+        firewallProtected
         onlyProvider
         validProviderId(poolId)
-        validParamsLength(params.length, currentParamsTargetLenght())
+        validParamsLength(params.length, currentParamsTargetLength())
     {
         _registerPool(poolId, params);
     }
@@ -34,7 +36,10 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
     /// @param params[0] = token amount
     /// @param params[params.length - 2] = main coin amount
     /// @param params[params.length - 1] = FinishTime
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal {
+    function _registerPool(uint256 poolId, uint256[] calldata params)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25)))
+    {
         uint256 tokenAmount = params[0];
         uint256 mainCoinAmount = params[params.length - 2];
         uint256 finishTime = params[params.length - 1];
@@ -53,7 +58,10 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         emit UpdateParams(poolId, params);
     }
 
-    function _setPoolProperties(uint256 poolId, uint256 rate, uint256 finishTime, uint256 mainCoinAmount) private {
+    function _setPoolProperties(uint256 poolId, uint256 rate, uint256 finishTime, uint256 mainCoinAmount)
+        private
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x91666b02)))
+    {
         poolIdToRateToWei[poolId] = rate;
         poolIdToTime[poolId] = finishTime;
         uint256[] memory mainCoinParams = new uint256[](1);
@@ -61,13 +69,16 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         provider.registerPool(poolId + 3, mainCoinParams); // Just need the 0 index, token left amount
     }
 
-    function _mintNFTs() private returns (uint256 poolId) {
+    function _mintNFTs() private firewallProtectedCustom(abi.encodePacked(bytes4(0x1cd0f8c5))) returns (uint256 poolId) {
         lockDealNFT.mintForProvider(address(this), provider); // Main Coin Collector
         lockDealNFT.mintForProvider(address(this), provider); // Token Collector
         poolId = lockDealNFT.mintForProvider(address(this), provider);
     }
 
-    function _cloneVaultIds(uint256 mainCoinPoolId) private {
+    function _cloneVaultIds(uint256 mainCoinPoolId)
+        private
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x720a8731)))
+    {
         lockDealNFT.cloneVaultId(mainCoinPoolId + 1, mainCoinPoolId);
         lockDealNFT.cloneVaultId(mainCoinPoolId + 3, mainCoinPoolId);
     }
@@ -78,7 +89,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
     }
 
     ///@dev newPoolId is collateral provider
-    function split(uint256 poolId, uint256, uint256 ratio) external override onlyNFT {
+    function split(uint256 poolId, uint256, uint256 ratio) external override firewallProtected onlyNFT {
         (uint256 mainCoinCollectorId, uint256 tokenCollectorId, uint256 mainCoinHolderId) = getInnerIds(poolId);
         uint256 tokenCollectorAmount = provider.getWithdrawableAmount(tokenCollectorId);
         uint256 coinCollectorAmount = provider.getWithdrawableAmount(mainCoinCollectorId);
@@ -91,7 +102,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         _splitter(coinHolderAmount, mainCoinHolderId, ratio);
     }
 
-    function _splitter(uint256 amount, uint256 poolId, uint256 ratio) internal {
+    function _splitter(uint256 amount, uint256 poolId, uint256 ratio) internal firewallProtectedCustom(abi.encodePacked(bytes4(0x203fb415))) {
         if (amount > 0) {
             lockDealNFT.safeTransferFrom(address(this), address(lockDealNFT), poolId, abi.encode(ratio));
         } else {
@@ -103,7 +114,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         uint256 poolId,
         address user,
         uint256 tokenAmount
-    ) public override onlyProvider validProviderId(poolId) {
+    ) external override firewallProtected onlyProvider validProviderId(poolId) {
         (, uint256 tokenCollectorId, uint256 mainCoinHolderId) = getInnerIds(poolId);
         uint256 mainCoinAmount = tokenAmount.calcAmount(poolIdToRateToWei[poolId]);
         provider.withdraw(mainCoinHolderId, mainCoinAmount);
@@ -115,7 +126,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         lockDealNFT.cloneVaultId(newMainCoinPoolId, mainCoinHolderId);
     }
 
-    function handleWithdraw(uint256 poolId, uint256 tokenAmount) public override onlyProvider validProviderId(poolId) {
+    function handleWithdraw(uint256 poolId, uint256 tokenAmount) external override firewallProtected onlyProvider validProviderId(poolId) {
         uint256 mainCoinCollectorId = poolId + 1;
         uint256 mainCoinHolderId = poolId + 3;
         uint256 mainCoinAmount = tokenAmount.calcAmount(poolIdToRateToWei[poolId]);
@@ -123,7 +134,7 @@ contract CollateralProvider is IFundsManager, ERC721Holder, CollateralState {
         _deposit(mainCoinCollectorId, mainCoinAmount);
     }
 
-    function _deposit(uint256 poolId, uint256 amount) internal {
+    function _deposit(uint256 poolId, uint256 amount) internal firewallProtectedCustom(abi.encodePacked(bytes4(0xf3207723))) {
         uint256[] memory params = provider.getParams(poolId);
         params[0] += amount;
         provider.registerPool(poolId, params);

--- a/contracts/AdvancedProviders/CollateralProvider/CollateralState.sol
+++ b/contracts/AdvancedProviders/CollateralProvider/CollateralState.sol
@@ -27,7 +27,7 @@ abstract contract CollateralState is LockDealState, IInnerWithdraw, IERC165, Pro
         }
     }
 
-    function currentParamsTargetLenght() public pure override returns (uint256) {
+    function currentParamsTargetLength() public pure override returns (uint256) {
         return 3;
     }
 

--- a/contracts/AdvancedProviders/RefundProvider/RefundProvider.sol
+++ b/contracts/AdvancedProviders/RefundProvider/RefundProvider.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "../../ERC165/Refundble.sol";
 import "./RefundState.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
-contract RefundProvider is RefundState, IERC721Receiver {
+contract RefundProvider is RefundState, IERC721Receiver, FirewallConsumer {
     constructor(ILockDealNFT nftContract, address provider) {
         require(address(nftContract) != address(0x0) && provider != address(0x0), "invalid address");
         lockDealNFT = nftContract;
@@ -19,7 +20,7 @@ contract RefundProvider is RefundState, IERC721Receiver {
         address user,
         uint256 poolId,
         bytes calldata
-    ) external override returns (bytes4) {
+    ) external override firewallProtected returns (bytes4) {
         require(msg.sender == address(lockDealNFT), "invalid nft contract");
         if (provider == user) {
             uint256 collateralPoolId = poolIdToCollateralId[poolId];
@@ -46,7 +47,7 @@ contract RefundProvider is RefundState, IERC721Receiver {
         uint256[] calldata params,
         bytes calldata tokenSignature,
         bytes calldata mainCoinSignature
-    ) external returns (uint256 poolId) {
+    ) external firewallProtected returns (uint256 poolId) {
         _validAddressLength(addresses.length, 4);
         _validProviderInterface(IProvider(addresses[3]), Refundble._INTERFACE_ID_REFUNDABLE);
         uint256 paramsLength = params.length;
@@ -78,7 +79,7 @@ contract RefundProvider is RefundState, IERC721Receiver {
         collateralProvider.registerPool(collateralPoolId, params);
         lockDealNFT.cloneVaultId(collateralPoolId + 2, dataPoolID); // clone token data to sub-collateral poolId
         // save refund data
-        uint256[] memory refundRegisterParams = new uint256[](currentParamsTargetLenght());
+        uint256[] memory refundRegisterParams = new uint256[](currentParamsTargetLength());
         refundRegisterParams[0] = collateralPoolId;
         _registerPool(poolId, refundRegisterParams);
     }
@@ -87,7 +88,7 @@ contract RefundProvider is RefundState, IERC721Receiver {
     function registerPool(
         uint256 poolId,
         uint256[] calldata params
-    ) public override onlyProvider validProviderId(poolId) validProviderAssociation(params[0], collateralProvider) {
+    ) external override firewallProtected onlyProvider validProviderId(poolId) validProviderAssociation(params[0], collateralProvider) {
         require(lockDealNFT.ownerOf(poolId + 1) == address(this), "Must Own poolId+1");
         _registerPool(poolId, params);
     }
@@ -95,14 +96,18 @@ contract RefundProvider is RefundState, IERC721Receiver {
     function _registerPool(
         uint256 poolId,
         uint256[] memory params
-    ) internal validParamsLength(params.length, currentParamsTargetLenght()) {
+    )
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25)))
+        validParamsLength(params.length, currentParamsTargetLength())
+    {
         poolIdToCollateralId[poolId] = params[0];
         emit UpdateParams(poolId, params);
     }
 
     ///@dev split tokens and main coins into new pools
-    function split(uint256 poolId, uint256 newPoolId, uint256 ratio) external onlyNFT {
-        uint256[] memory params = new uint256[](currentParamsTargetLenght());
+    function split(uint256 poolId, uint256 newPoolId, uint256 ratio) external firewallProtected onlyNFT {
+        uint256[] memory params = new uint256[](currentParamsTargetLength());
         params[0] = poolIdToCollateralId[poolId];
         _registerPool(newPoolId, params);
         uint256 userPoolId = poolId + 1;
@@ -110,7 +115,7 @@ contract RefundProvider is RefundState, IERC721Receiver {
     }
 
     ///@dev user withdraws his tokens
-    function withdraw(uint256 poolId) public override onlyNFT returns (uint256 amountToBeWithdrawed, bool isFinal) {
+    function withdraw(uint256 poolId) external override firewallProtected onlyNFT returns (uint256 amountToBeWithdrawed, bool isFinal) {
         uint256 userDataPoolId = poolId + 1;
         IProvider provider = lockDealNFT.poolIdToProvider(userDataPoolId);
         amountToBeWithdrawed = provider.getWithdrawableAmount(userDataPoolId);

--- a/contracts/AdvancedProviders/RefundProvider/RefundProvider.sol
+++ b/contracts/AdvancedProviders/RefundProvider/RefundProvider.sol
@@ -98,7 +98,7 @@ contract RefundProvider is RefundState, IERC721Receiver, FirewallConsumer {
         uint256[] memory params
     )
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25)))
+        firewallProtectedSig(0xdf3aac25)
         validParamsLength(params.length, currentParamsTargetLength())
     {
         poolIdToCollateralId[poolId] = params[0];

--- a/contracts/AdvancedProviders/RefundProvider/RefundState.sol
+++ b/contracts/AdvancedProviders/RefundProvider/RefundState.sol
@@ -24,7 +24,7 @@ abstract contract RefundState is ProviderModifiers, IInnerWithdraw, IERC165 {
         }
     }
 
-    function currentParamsTargetLenght() public pure override returns (uint256) {
+    function currentParamsTargetLength() public pure override returns (uint256) {
         return 1;
     }
 

--- a/contracts/Builders/SimpleBuilder/SimpleBuilder.sol
+++ b/contracts/Builders/SimpleBuilder/SimpleBuilder.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import "../Builder/BuilderInternal.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
 /// @title SimpleBuilder contract
 /// @notice This contract is used to create mass lock deals(NFTs)
-contract SimpleBuilder is ERC721Holder, BuilderInternal {
+contract SimpleBuilder is ERC721Holder, BuilderInternal, FirewallConsumer {
     constructor(ILockDealNFT _nft) {
         lockDealNFT = _nft;
     }
@@ -21,7 +22,7 @@ contract SimpleBuilder is ERC721Holder, BuilderInternal {
         Builder calldata userData,
         uint256[] calldata params,
         bytes calldata signature
-    ) external notZeroAddress(addressParams[1]) {
+    ) external firewallProtected notZeroAddress(addressParams[1]) {
         _validParamsLength(addressParams.length, 2);
         require(
             ERC165Checker.supportsInterface(addressParams[0], type(ISimpleProvider).interfaceId),

--- a/contracts/Builders/SimpleRefundBuilder/SimpleRefundBuilder.sol
+++ b/contracts/Builders/SimpleRefundBuilder/SimpleRefundBuilder.sol
@@ -5,10 +5,11 @@ import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import "../../interfaces/ISimpleProvider.sol";
 import "../Builder/BuilderInternal.sol";
 import "../../util/CalcUtils.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
 /// @title SimpleRefundBuilder contract
 /// @notice Implements a contract for building refund simple providers
-contract SimpleRefundBuilder is ERC721Holder, BuilderInternal {
+contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer {
     using CalcUtils for uint256;
     IProvider public refundProvider;
     IProvider public collateralProvider;
@@ -38,7 +39,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal {
         uint256[][] calldata params,
         bytes calldata tokenSignature,
         bytes calldata mainCoinSignature
-    ) public {
+    ) external firewallProtected {
         ParamsData memory paramsData = _validateParamsData(addressParams, params);
         require(userData.userPools.length > 0, "invalid user length");
         uint256 totalAmount = userData.totalAmount;
@@ -70,7 +71,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal {
         uint256 totalAmount,
         uint256[] memory params,
         bytes calldata signature
-    ) internal virtual override returns (uint256 poolId) {
+    ) internal virtual override firewallProtectedCustom(abi.encodePacked(bytes4(0x29454335))) returns (uint256 poolId) {
         // one time token transfer for deacrease number transactions
         lockDealNFT.mintForProvider(owner, refundProvider);
         poolId = super._createFirstNFT(provider, token, address(refundProvider), totalAmount, params, signature);
@@ -83,7 +84,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal {
         uint256 mainCoinAmount,
         uint256 collateralFinishTime,
         bytes calldata signature
-    ) internal returns (uint256 poolId) {
+    ) internal firewallProtectedCustom(abi.encodePacked(bytes4(0x4516d406))) returns (uint256 poolId) {
         poolId = lockDealNFT.safeMintAndTransfer(
             msg.sender,
             mainCoin,
@@ -126,7 +127,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal {
         uint256 mainCoinAmount,
         uint256 collateralFinishTime,
         bytes calldata signature
-    ) internal returns (uint256[] memory refundParams) {
+    ) internal firewallProtectedCustom(abi.encodePacked(bytes4(0xcfc2dc78))) returns (uint256[] memory refundParams) {
         refundParams = new uint256[](1);
         refundParams[0] = _createCollateralProvider(
             mainCoin,
@@ -146,7 +147,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal {
         uint256 tokenPoolId,
         uint256[] memory simpleParams,
         uint256[] memory refundParams
-    ) internal {
+    ) internal firewallProtectedCustom(abi.encodePacked(bytes4(0xbbc1f709))) {
         uint256 length = userData.length;
         require(length > 0, "invalid userPools length");
         totalAmount -= userData[0].amount;

--- a/contracts/Builders/SimpleRefundBuilder/SimpleRefundBuilder.sol
+++ b/contracts/Builders/SimpleRefundBuilder/SimpleRefundBuilder.sol
@@ -71,7 +71,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer 
         uint256 totalAmount,
         uint256[] memory params,
         bytes calldata signature
-    ) internal virtual override firewallProtectedCustom(abi.encodePacked(bytes4(0x29454335))) returns (uint256 poolId) {
+    ) internal virtual override firewallProtectedSig(0x29454335) returns (uint256 poolId) {
         // one time token transfer for deacrease number transactions
         lockDealNFT.mintForProvider(owner, refundProvider);
         poolId = super._createFirstNFT(provider, token, address(refundProvider), totalAmount, params, signature);
@@ -84,7 +84,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer 
         uint256 mainCoinAmount,
         uint256 collateralFinishTime,
         bytes calldata signature
-    ) internal firewallProtectedCustom(abi.encodePacked(bytes4(0x4516d406))) returns (uint256 poolId) {
+    ) internal firewallProtectedSig(0x4516d406) returns (uint256 poolId) {
         poolId = lockDealNFT.safeMintAndTransfer(
             msg.sender,
             mainCoin,
@@ -127,7 +127,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer 
         uint256 mainCoinAmount,
         uint256 collateralFinishTime,
         bytes calldata signature
-    ) internal firewallProtectedCustom(abi.encodePacked(bytes4(0xcfc2dc78))) returns (uint256[] memory refundParams) {
+    ) internal firewallProtectedSig(0xcfc2dc78) returns (uint256[] memory refundParams) {
         refundParams = new uint256[](1);
         refundParams[0] = _createCollateralProvider(
             mainCoin,
@@ -147,7 +147,7 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer 
         uint256 tokenPoolId,
         uint256[] memory simpleParams,
         uint256[] memory refundParams
-    ) internal firewallProtectedCustom(abi.encodePacked(bytes4(0xbbc1f709))) {
+    ) internal firewallProtectedSig(0xbbc1f709) {
         uint256 length = userData.length;
         require(length > 0, "invalid userPools length");
         totalAmount -= userData[0].amount;

--- a/contracts/LockDealNFT/LockDealNFT.sol
+++ b/contracts/LockDealNFT/LockDealNFT.sol
@@ -18,7 +18,7 @@ contract LockDealNFT is LockDealNFTInternal, IERC721Receiver {
     function mintForProvider(
         address owner,
         IProvider provider
-    ) external onlyApprovedContract(address(provider)) notZeroAddress(owner) returns (uint256 poolId) {
+    ) external firewallProtected onlyApprovedContract(address(provider)) notZeroAddress(owner) returns (uint256 poolId) {
         poolId = _mint(owner, provider);
     }
 
@@ -28,7 +28,8 @@ contract LockDealNFT is LockDealNFTInternal, IERC721Receiver {
         uint256 amount,
         IProvider provider
     )
-        public
+        external
+        firewallProtected
         onlyApprovedContract(address(provider))
         notZeroAddress(owner)
         notZeroAddress(token)
@@ -48,7 +49,8 @@ contract LockDealNFT is LockDealNFTInternal, IERC721Receiver {
         IProvider provider,
         bytes calldata data
     )
-        public
+        external
+        firewallProtected
         onlyApprovedContract(address(provider))
         notZeroAddress(owner)
         notZeroAddress(token)
@@ -62,7 +64,7 @@ contract LockDealNFT is LockDealNFTInternal, IERC721Receiver {
     function cloneVaultId(
         uint256 destinationPoolId,
         uint256 sourcePoolId
-    ) external onlyApprovedContract(msg.sender) validPoolId(destinationPoolId) validPoolId(sourcePoolId) {
+    ) external firewallProtected onlyApprovedContract(msg.sender) validPoolId(destinationPoolId) validPoolId(sourcePoolId) {
         poolIdToVaultId[destinationPoolId] = poolIdToVaultId[sourcePoolId];
     }
 
@@ -85,7 +87,7 @@ contract LockDealNFT is LockDealNFTInternal, IERC721Receiver {
         address from,
         uint256 poolId,
         bytes calldata data
-    ) external override returns (bytes4) {
+    ) external override firewallProtected returns (bytes4) {
         require(msg.sender == address(this), "invalid nft contract");
         _handleReturn(poolId, from, data.length > 0 ? _split(poolId, from, data) : _withdraw(from, poolId));
         return IERC721Receiver.onERC721Received.selector;

--- a/contracts/LockDealNFT/LockDealNFTInternal.sol
+++ b/contracts/LockDealNFT/LockDealNFTInternal.sol
@@ -5,9 +5,14 @@ import "./LockDealNFTModifiers.sol";
 import "../interfaces/IInnerWithdraw.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "../interfaces/IBeforeTransfer.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
-abstract contract LockDealNFTInternal is LockDealNFTModifiers {
-    function _transfer(address from, address to, uint256 poolId) internal override {
+abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer {
+    function _transfer(address from, address to, uint256 poolId)
+        internal
+        override
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x30e0789e)))
+    {
         if (
             from != address(0) &&
             ERC165Checker.supportsInterface(address(poolIdToProvider[poolId]), type(IBeforeTransfer).interfaceId)
@@ -28,7 +33,11 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers {
     /// @param owner The address to assign the token to
     /// @param provider The address of the provider assigning the token
     /// @return newPoolId The ID of the pool
-    function _mint(address owner, IProvider provider) internal returns (uint256 newPoolId) {
+    function _mint(address owner, IProvider provider)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x3c99ae44)))
+        returns (uint256 newPoolId)
+    {
         newPoolId = totalSupply();
         _safeMint(owner, newPoolId);
         poolIdToProvider[newPoolId] = provider;
@@ -44,13 +53,19 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers {
         return baseURI;
     }
 
-    function _handleReturn(uint256 poolId, address from, bool isFinal) internal {
+    function _handleReturn(uint256 poolId, address from, bool isFinal)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x1d50d0db)))
+    {
         if (!isFinal) {
             _transfer(address(this), from, poolId);
         }
     }
 
-    function _withdrawFromVault(uint256 poolId, uint256 withdrawnAmount, address from) internal {
+    function _withdrawFromVault(uint256 poolId, uint256 withdrawnAmount, address from)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x05d6a92f)))
+    {
         if (withdrawnAmount > 0) {
             vaultManager.withdrawByVaultId(poolIdToVaultId[poolId], from, withdrawnAmount);
             emit MetadataUpdate(poolId);
@@ -58,7 +73,11 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers {
         }
     }
 
-    function _withdraw(address from, uint256 poolId) internal returns (bool isFinal) {
+    function _withdraw(address from, uint256 poolId)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0xb790a77b)))
+        returns (bool isFinal)
+    {
         uint256 withdrawnAmount;
         IProvider provider = poolIdToProvider[poolId];
         (withdrawnAmount, isFinal) = provider.withdraw(poolId);
@@ -76,7 +95,11 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers {
 
     /// @dev Splits a pool into two pools with adjusted amounts
     /// @param poolId The ID of the pool to split
-    function _split(uint256 poolId, address from, bytes calldata data) internal returns (bool isFinal) {
+    function _split(uint256 poolId, address from, bytes calldata data)
+        internal
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x1746b892)))
+        returns (bool isFinal)
+    {
         (uint256 ratio, address newOwner) = _parseData(data, from);
         isFinal = _split(poolId, from, ratio, newOwner);
     }
@@ -86,7 +109,13 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers {
         address from,
         uint256 ratio,
         address newOwner
-    ) private notZeroAddress(newOwner) notZeroAmount(ratio) returns (bool isFinal) {
+    )
+        private
+        firewallProtectedCustom(abi.encodePacked(bytes4(0x5936f8f8)))
+        notZeroAddress(newOwner)
+        notZeroAmount(ratio)
+        returns (bool isFinal)
+    {
         require(ratio <= 1e21, "split amount exceeded");
         IProvider provider = poolIdToProvider[poolId];
         uint256 newPoolId = _mint(newOwner, provider);

--- a/contracts/LockDealNFT/LockDealNFTInternal.sol
+++ b/contracts/LockDealNFT/LockDealNFTInternal.sol
@@ -11,7 +11,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
     function _transfer(address from, address to, uint256 poolId)
         internal
         override
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x30e0789e)))
+        firewallProtectedSig(0x30e0789e)
     {
         if (
             from != address(0) &&
@@ -35,7 +35,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
     /// @return newPoolId The ID of the pool
     function _mint(address owner, IProvider provider)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x3c99ae44)))
+        firewallProtectedSig(0x3c99ae44)
         returns (uint256 newPoolId)
     {
         newPoolId = totalSupply();
@@ -55,7 +55,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
 
     function _handleReturn(uint256 poolId, address from, bool isFinal)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x1d50d0db)))
+        firewallProtectedSig(0x1d50d0db)
     {
         if (!isFinal) {
             _transfer(address(this), from, poolId);
@@ -64,7 +64,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
 
     function _withdrawFromVault(uint256 poolId, uint256 withdrawnAmount, address from)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x05d6a92f)))
+        firewallProtectedSig(0x05d6a92f)
     {
         if (withdrawnAmount > 0) {
             vaultManager.withdrawByVaultId(poolIdToVaultId[poolId], from, withdrawnAmount);
@@ -75,7 +75,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
 
     function _withdraw(address from, uint256 poolId)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0xb790a77b)))
+        firewallProtectedSig(0xb790a77b)
         returns (bool isFinal)
     {
         uint256 withdrawnAmount;
@@ -97,7 +97,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
     /// @param poolId The ID of the pool to split
     function _split(uint256 poolId, address from, bytes calldata data)
         internal
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x1746b892)))
+        firewallProtectedSig(0x1746b892)
         returns (bool isFinal)
     {
         (uint256 ratio, address newOwner) = _parseData(data, from);
@@ -111,7 +111,7 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
         address newOwner
     )
         private
-        firewallProtectedCustom(abi.encodePacked(bytes4(0x5936f8f8)))
+        firewallProtectedSig(0x5936f8f8)
         notZeroAddress(newOwner)
         notZeroAmount(ratio)
         returns (bool isFinal)

--- a/contracts/SimpleProviders/DealProvider/DealProvider.sol
+++ b/contracts/SimpleProviders/DealProvider/DealProvider.sol
@@ -17,7 +17,7 @@ contract DealProvider is DealProviderState, BasicProvider {
     function _withdraw(
         uint256 poolId,
         uint256 amount
-    ) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0x9e2bf22c))) returns (uint256 withdrawnAmount, bool isFinal) {
+    ) internal override firewallProtectedSig(0x9e2bf22c) returns (uint256 withdrawnAmount, bool isFinal) {
         if (poolIdToAmount[poolId] >= amount) {
             poolIdToAmount[poolId] -= amount;
             withdrawnAmount = amount;
@@ -37,7 +37,7 @@ contract DealProvider is DealProviderState, BasicProvider {
      * @param poolId The ID of the pool.
      * @param params An array of additional parameters.
      */
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25))) {
+    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedSig(0xdf3aac25) {
         poolIdToAmount[poolId] = params[0];
         emit UpdateParams(poolId, params);
     }

--- a/contracts/SimpleProviders/DealProvider/DealProvider.sol
+++ b/contracts/SimpleProviders/DealProvider/DealProvider.sol
@@ -17,7 +17,7 @@ contract DealProvider is DealProviderState, BasicProvider {
     function _withdraw(
         uint256 poolId,
         uint256 amount
-    ) internal override returns (uint256 withdrawnAmount, bool isFinal) {
+    ) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0x9e2bf22c))) returns (uint256 withdrawnAmount, bool isFinal) {
         if (poolIdToAmount[poolId] >= amount) {
             poolIdToAmount[poolId] -= amount;
             withdrawnAmount = amount;
@@ -26,7 +26,7 @@ contract DealProvider is DealProviderState, BasicProvider {
     }
 
     /// @dev Splits a pool into two pools. Used by the LockedDealNFT contract or Provider
-    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) public override onlyProvider {
+    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) external override firewallProtected onlyProvider {
         uint256 splitAmount = poolIdToAmount[oldPoolId].calcAmount(ratio);
         require(poolIdToAmount[oldPoolId] >= splitAmount, "Split amount exceeds the available amount");
         poolIdToAmount[oldPoolId] -= splitAmount;
@@ -37,7 +37,7 @@ contract DealProvider is DealProviderState, BasicProvider {
      * @param poolId The ID of the pool.
      * @param params An array of additional parameters.
      */
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal override {
+    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25))) {
         poolIdToAmount[poolId] = params[0];
         emit UpdateParams(poolId, params);
     }

--- a/contracts/SimpleProviders/LockProvider/LockDealProvider.sol
+++ b/contracts/SimpleProviders/LockProvider/LockDealProvider.sol
@@ -36,7 +36,7 @@ contract LockDealProvider is BasicProvider, LockDealState {
 
     ///@param params[0] = amount
     ///@param params[1] = startTime
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25))) {
+    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedSig(0xdf3aac25) {
         require(block.timestamp <= params[1], "Invalid start time");
 
         poolIdToTime[poolId] = params[1];

--- a/contracts/SimpleProviders/LockProvider/LockDealProvider.sol
+++ b/contracts/SimpleProviders/LockProvider/LockDealProvider.sol
@@ -13,7 +13,7 @@ contract LockDealProvider is BasicProvider, LockDealState {
     }
 
     /// @dev use revert only for permissions
-    function withdraw(uint256 poolId) public override onlyNFT returns (uint256 withdrawnAmount, bool isFinal) {
+    function withdraw(uint256 poolId) external override firewallProtected onlyNFT returns (uint256 withdrawnAmount, bool isFinal) {
         (withdrawnAmount, isFinal) = _withdraw(poolId, getParams(poolId)[0]);
     }
 
@@ -25,18 +25,18 @@ contract LockDealProvider is BasicProvider, LockDealState {
         (withdrawnAmount, isFinal) = provider.withdraw(poolId, amount > withdrawnAmount ? withdrawnAmount : amount);
     }
 
-    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) public override onlyProvider {
+    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) external override firewallProtected onlyProvider {
         provider.split(oldPoolId, newPoolId, ratio);
         poolIdToTime[newPoolId] = poolIdToTime[oldPoolId];
     }
 
-    function currentParamsTargetLenght() public view override(IProvider, ProviderState) returns (uint256) {
-        return 1 + provider.currentParamsTargetLenght();
+    function currentParamsTargetLength() public view override(IProvider, ProviderState) returns (uint256) {
+        return 1 + provider.currentParamsTargetLength();
     }
 
     ///@param params[0] = amount
     ///@param params[1] = startTime
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal override {
+    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25))) {
         require(block.timestamp <= params[1], "Invalid start time");
 
         poolIdToTime[poolId] = params[1];

--- a/contracts/SimpleProviders/Provider/BasicProvider.sol
+++ b/contracts/SimpleProviders/Provider/BasicProvider.sol
@@ -7,8 +7,9 @@ import "../../interfaces/ISimpleProvider.sol";
 import "../../ERC165/Refundble.sol";
 import "../../ERC165/Bundable.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 
-abstract contract BasicProvider is ProviderModifiers, ISimpleProvider, ERC165 {
+abstract contract BasicProvider is ProviderModifiers, ISimpleProvider, ERC165, FirewallConsumer {
     /**
      * @dev Creates a new pool with the specified parameters.
      * @param addresses[0] The address of the pool owner.
@@ -22,10 +23,11 @@ abstract contract BasicProvider is ProviderModifiers, ISimpleProvider, ERC165 {
         uint256[] calldata params,
         bytes calldata signature
     )
-        public
+        external
         virtual
+        firewallProtected
         validAddressesLength(addresses.length, 2)
-        validParamsLength(params.length, currentParamsTargetLenght())
+        validParamsLength(params.length, currentParamsTargetLength())
         returns (uint256 poolId)
     {
         poolId = lockDealNFT.safeMintAndTransfer(addresses[0], addresses[1], msg.sender, params[0], this, signature);
@@ -36,7 +38,7 @@ abstract contract BasicProvider is ProviderModifiers, ISimpleProvider, ERC165 {
     function registerPool(
         uint256 poolId,
         uint256[] calldata params
-    ) public virtual onlyProvider validParamsLength(params.length, currentParamsTargetLenght()) {
+    ) external virtual firewallProtected onlyProvider validParamsLength(params.length, currentParamsTargetLength()) {
         _registerPool(poolId, params);
     }
 
@@ -46,7 +48,7 @@ abstract contract BasicProvider is ProviderModifiers, ISimpleProvider, ERC165 {
      * @return withdrawnAmount The amount of tokens withdrawn.
      * @return isFinal Boolean indicating whether the pool is empty after a withdrawal.
      */
-    function withdraw(uint256 poolId) public virtual override onlyNFT returns (uint256 withdrawnAmount, bool isFinal) {
+    function withdraw(uint256 poolId) external virtual firewallProtected override onlyNFT returns (uint256 withdrawnAmount, bool isFinal) {
         (withdrawnAmount, isFinal) = _withdraw(poolId, getWithdrawableAmount(poolId));
     }
 
@@ -54,7 +56,7 @@ abstract contract BasicProvider is ProviderModifiers, ISimpleProvider, ERC165 {
     function withdraw(
         uint256 poolId,
         uint256 amount
-    ) public virtual onlyProvider returns (uint256 withdrawnAmount, bool isFinal) {
+    ) external virtual firewallProtected onlyProvider returns (uint256 withdrawnAmount, bool isFinal) {
         (withdrawnAmount, isFinal) = _withdraw(poolId, amount);
     }
 

--- a/contracts/SimpleProviders/Provider/ProviderState.sol
+++ b/contracts/SimpleProviders/Provider/ProviderState.sol
@@ -9,7 +9,7 @@ abstract contract ProviderState is IProvider {
     ILockDealNFT public lockDealNFT;
 
     ///@dev each provider decides how many parameters it needs by overriding this function
-    function currentParamsTargetLenght() public view virtual returns (uint256) {
+    function currentParamsTargetLength() public view virtual returns (uint256) {
         return 1;
     }
 

--- a/contracts/SimpleProviders/TimedDealProvider/TimedDealProvider.sol
+++ b/contracts/SimpleProviders/TimedDealProvider/TimedDealProvider.sol
@@ -24,7 +24,7 @@ contract TimedDealProvider is LockDealState, DealProviderState, BasicProvider {
     function _withdraw(
         uint256 poolId,
         uint256 amount
-    ) internal override returns (uint256 withdrawnAmount, bool isFinal) {
+    ) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0x9e2bf22c))) returns (uint256 withdrawnAmount, bool isFinal) {
         (withdrawnAmount, isFinal) = provider.withdraw(poolId, amount);
     }
 
@@ -44,7 +44,7 @@ contract TimedDealProvider is LockDealState, DealProviderState, BasicProvider {
         return debitableAmount - (startAmount - leftAmount);
     }
 
-    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) public onlyProvider {
+    function split(uint256 oldPoolId, uint256 newPoolId, uint256 ratio) external firewallProtected onlyProvider {
         provider.split(oldPoolId, newPoolId, ratio);
         uint256 newPoolStartAmount = poolIdToAmount[oldPoolId].calcAmount(ratio);
         poolIdToAmount[oldPoolId] -= newPoolStartAmount;
@@ -55,7 +55,7 @@ contract TimedDealProvider is LockDealState, DealProviderState, BasicProvider {
     ///@param params[0] = leftAmount = startAmount (leftAmount & startAmount must be same while creating pool)
     ///@param params[1] = startTime
     ///@param params[2] = finishTime
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal override {
+    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25))) {
         require(params[2] >= params[1], "Finish time should be greater than start time");
         poolIdToTime[poolId] = params[2];
         poolIdToAmount[poolId] = params[0];
@@ -73,7 +73,7 @@ contract TimedDealProvider is LockDealState, DealProviderState, BasicProvider {
         params[3] = poolIdToAmount[poolId]; // startAmount
     }
 
-    function currentParamsTargetLenght() public view override(IProvider, ProviderState) returns (uint256) {
-        return 1 + provider.currentParamsTargetLenght();
+    function currentParamsTargetLength() public view override(IProvider, ProviderState) returns (uint256) {
+        return 1 + provider.currentParamsTargetLength();
     }
 }

--- a/contracts/SimpleProviders/TimedDealProvider/TimedDealProvider.sol
+++ b/contracts/SimpleProviders/TimedDealProvider/TimedDealProvider.sol
@@ -24,7 +24,7 @@ contract TimedDealProvider is LockDealState, DealProviderState, BasicProvider {
     function _withdraw(
         uint256 poolId,
         uint256 amount
-    ) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0x9e2bf22c))) returns (uint256 withdrawnAmount, bool isFinal) {
+    ) internal override firewallProtectedSig(0x9e2bf22c) returns (uint256 withdrawnAmount, bool isFinal) {
         (withdrawnAmount, isFinal) = provider.withdraw(poolId, amount);
     }
 
@@ -55,7 +55,7 @@ contract TimedDealProvider is LockDealState, DealProviderState, BasicProvider {
     ///@param params[0] = leftAmount = startAmount (leftAmount & startAmount must be same while creating pool)
     ///@param params[1] = startTime
     ///@param params[2] = finishTime
-    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedCustom(abi.encodePacked(bytes4(0xdf3aac25))) {
+    function _registerPool(uint256 poolId, uint256[] calldata params) internal override firewallProtectedSig(0xdf3aac25) {
         require(params[2] >= params[1], "Finish time should be greater than start time");
         poolIdToTime[poolId] = params[2];
         poolIdToAmount[poolId] = params[0];

--- a/contracts/interfaces/IProvider.sol
+++ b/contracts/interfaces/IProvider.sol
@@ -16,7 +16,7 @@ interface IProvider {
 
     function getWithdrawableAmount(uint256 poolId) external view returns (uint256 withdrawalAmount);
 
-    function currentParamsTargetLenght() external view returns (uint256);
+    function currentParamsTargetLength() external view returns (uint256);
 
     function name() external view returns (string memory);
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,14 +9,29 @@ import 'solidity-coverage'
 const config: HardhatUserConfig = {
   defaultNetwork: 'hardhat',
   solidity: {
-    version: '0.8.18',
-    settings: {
-      evmVersion: 'istanbul',
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.19",
+        settings: {
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: '0.8.18',
+        settings: {
+          viaIR: true,
+          evmVersion: 'istanbul',
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
+    "@ironblocks/firewall-consumer": "^1.0.1",
     "@openzeppelin/contracts": "^4.8.3",
     "@poolzfinance/poolz-helper-v2": "^2.1.15"
   },
@@ -20,6 +21,7 @@
     "@nomiclabs/hardhat-ethers": "^2.2.1",
     "@nomiclabs/hardhat-etherscan": "^3.1.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
+    "@truffle/dashboard-hardhat-plugin": "0.2.7",
     "@typechain/ethers-v5": "^10.1.1",
     "@typechain/hardhat": "^6.1.4",
     "@types/chai": "^4.3.4",
@@ -27,9 +29,9 @@
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
-    "@truffle/dashboard-hardhat-plugin": "0.2.7",
     "@typescript-eslint/parser": "^5.44.0",
     "chai": "^4.3.7",
+    "dotenv": "^16.3.1",
     "ethers": "^5.7.2",
     "fs-extra": "^10.1.0",
     "hardhat": "^2.15.0",
@@ -41,8 +43,7 @@
     "ts-generator": "^0.1.1",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.1",
-    "typescript": "^4.9.3",
-    "dotenv": "^16.3.1"
+    "typescript": "^4.9.3"
   },
   "keywords": []
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@ironblocks/firewall-consumer": "^1.0.1",
+    "@ironblocks/firewall-consumer": "^1.0.4",
     "@openzeppelin/contracts": "^4.8.3",
     "@poolzfinance/poolz-helper-v2": "^2.1.15"
   },


### PR DESCRIPTION
This PR introduces the Ironblocks Firewall into the new Poolz contract, leaving it disabled initially until enabled by the owners. Key changes are

- Included `firewallProtected` to all relevant external functions, and `firewallProtectedCustom` to all relevant internal functions.
- Made public functions which didn't need to be public external, a soft requirement for the `firewallProtected` modifier which also includes some gas savings.
- Fixed `currentParamsTargetLenght` typo. If there are already deployed external contracts which depend on this function we should revert this since this signature hash will change.