### PR TITLE
use structs instead of viaIR

### DIFF
--- a/contracts/Builders/SimpleRefundBuilder/SimpleRefundBuilder.sol
+++ b/contracts/Builders/SimpleRefundBuilder/SimpleRefundBuilder.sol
@@ -27,6 +27,14 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer 
         uint256 mainCoinAmount;
     }
 
+    struct MassPoolsLocals {
+        ParamsData paramsData;
+        uint256[] simpleParams;
+        uint256 totalAmount;
+        uint256 poolId;
+        uint256[] refundParams;
+    }
+
     /// @param addressParams[0] = simpleProvider
     /// @param addressParams[1] = token
     /// @param addressParams[2] = mainCoin
@@ -40,28 +48,29 @@ contract SimpleRefundBuilder is ERC721Holder, BuilderInternal, FirewallConsumer 
         bytes calldata tokenSignature,
         bytes calldata mainCoinSignature
     ) external firewallProtected {
-        ParamsData memory paramsData = _validateParamsData(addressParams, params);
+        MassPoolsLocals memory locals;
+        locals.paramsData = _validateParamsData(addressParams, params);
         require(userData.userPools.length > 0, "invalid user length");
-        uint256 totalAmount = userData.totalAmount;
-        require(totalAmount > 0, "invalid totalAmount");
-        uint256[] memory simpleParams = _concatParams(userData.userPools[0].amount, params[1]);
-        uint256 poolId = _createFirstNFT(
-            paramsData.provider,
-            paramsData.token,
+        locals.totalAmount = userData.totalAmount;
+        require(locals.totalAmount > 0, "invalid totalAmount");
+        locals.simpleParams = _concatParams(userData.userPools[0].amount, params[1]);
+        locals.poolId = _createFirstNFT(
+            locals.paramsData.provider,
+            locals.paramsData.token,
             userData.userPools[0].user,
-            totalAmount,
-            simpleParams,
+            locals.totalAmount,
+            locals.simpleParams,
             tokenSignature
         );
-        uint256[] memory refundParams = _finalizeFirstNFT(
-            poolId - 1,
-            paramsData.mainCoin,
-            totalAmount,
-            paramsData.mainCoinAmount,
+        locals.refundParams = _finalizeFirstNFT(
+            locals.poolId - 1,
+            locals.paramsData.mainCoin,
+            locals.totalAmount,
+            locals.paramsData.mainCoinAmount,
             params[0][1],
             mainCoinSignature
         );
-        _userDataIterator(paramsData.provider, userData.userPools, totalAmount, poolId, simpleParams, refundParams);
+        _userDataIterator(locals.paramsData.provider, userData.userPools, locals.totalAmount, locals.poolId, locals.simpleParams, locals.refundParams);
     }
 
     function _createFirstNFT(

--- a/contracts/LockDealNFT/LockDealNFTInternal.sol
+++ b/contracts/LockDealNFT/LockDealNFTInternal.sol
@@ -104,6 +104,11 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
         isFinal = _split(poolId, from, ratio, newOwner);
     }
 
+    struct SplitLocals {
+        IProvider provider;
+        uint256 newPoolId;
+    }
+
     function _split(
         uint256 poolId,
         address from,
@@ -117,12 +122,13 @@ abstract contract LockDealNFTInternal is LockDealNFTModifiers, FirewallConsumer 
         returns (bool isFinal)
     {
         require(ratio <= 1e21, "split amount exceeded");
-        IProvider provider = poolIdToProvider[poolId];
-        uint256 newPoolId = _mint(newOwner, provider);
-        poolIdToVaultId[newPoolId] = poolIdToVaultId[poolId];
-        provider.split(poolId, newPoolId, ratio);
-        isFinal = provider.getParams(poolId)[0] == 0;
-        emit PoolSplit(poolId, from, newPoolId, newOwner, _getData(poolId).params[0], _getData(newPoolId).params[0]);
+        SplitLocals memory locals;
+        locals.provider = poolIdToProvider[poolId];
+        locals.newPoolId = _mint(newOwner, locals.provider);
+        poolIdToVaultId[locals.newPoolId] = poolIdToVaultId[poolId];
+        locals.provider.split(poolId, locals.newPoolId, ratio);
+        isFinal = locals.provider.getParams(poolId)[0] == 0;
+        emit PoolSplit(poolId, from, locals.newPoolId, newOwner, _getData(poolId).params[0], _getData(locals.newPoolId).params[0]);
         emit MetadataUpdate(poolId);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,7 +2,7 @@ import '@nomicfoundation/hardhat-toolbox';
 import '@truffle/dashboard-hardhat-plugin';
 import 'hardhat-gas-reporter';
 import { HardhatUserConfig } from 'hardhat/config';
-import 'solidity-coverage'
+import 'solidity-coverage';
 
 //import 'dotenv/config';
 
@@ -11,9 +11,8 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.19",
+        version: '0.8.19',
         settings: {
-          viaIR: true,
           optimizer: {
             enabled: true,
             runs: 200,
@@ -23,7 +22,6 @@ const config: HardhatUserConfig = {
       {
         version: '0.8.18',
         settings: {
-          viaIR: true,
           evmVersion: 'istanbul',
           optimizer: {
             enabled: true,


### PR DESCRIPTION
Alternative way to fix `stack too deep` error.

Solidity can generate `EVM` bytecode in two different ways: Either directly from Solidity to `EVM` opcodes (“old codegen”) or through an intermediate representation (“IR”) in `Yul` (“new codegen” or “IR-based codegen”).

Reasons to use structs.
* Setting `viaIR` to true in compiler settings results in zero coverage [link](https://github.com/sc-forks/solidity-coverage/issues/715)
* `Hardhat` don't completely support the `viaIR` option yet. [link](https://hardhat.org/hardhat-runner/docs/reference/solidity-support#support-for-ir-based-codegen)